### PR TITLE
solving some errors

### DIFF
--- a/src/controller/fatiasController.js
+++ b/src/controller/fatiasController.js
@@ -76,7 +76,7 @@ endpoints.post("/fatias", async (req, res) => {
 
   let resultExist = await fatias.getFatiaByNome(fatia.nome);
 
-  if (resultExist) {
+  if (resultExist.length > 0) {
     return res.status(403).send({
       message: "Fatia já cadastrada"
     });

--- a/src/repository/bolosRepository.js
+++ b/src/repository/bolosRepository.js
@@ -3,7 +3,7 @@ import connection from "../services/connection.js";
 // Função para buscar todos os bolos
 export async function getAllBolos() {
   const query = `
-    SELECT * FROM view_bolo_ingredientes;
+    SELECT * FROM bolo;
   `;
 
   let [bolos] = await connection.query(query);

--- a/src/repository/fatiasRepository.js
+++ b/src/repository/fatiasRepository.js
@@ -3,7 +3,7 @@ import connection from "../services/connection.js";
 // Função para buscar todos os fatias
 export async function getAllFatias() {
   const query = `
-    SELECT * FROM view_fatia_ingredientes;
+    SELECT * FROM fatia;
   `;
 
   let [fatias] = await connection.query(query);
@@ -14,7 +14,7 @@ export async function getAllFatias() {
 // Função para adicionar fatia
 export async function addFatia(fatia, ingredientes) {
   const query = `
-    INSERT INTO fatia (nome_fatia, massa, recheio, cobertura, peso_kg, valor)
+    INSERT INTO fatia (nome_fatia, massa, recheio, cobertura, peso_g, valor)
     VALUES (?, ?, ?, ?, ?, ?);
   `;
 
@@ -31,25 +31,25 @@ export async function addFatia(fatia, ingredientes) {
 
   ingredientes.forEach(element => {
     const query = `
-      INSERT INTO fatia_ingredientes (id_fatia, ingrediente)
+      INSERT INTO fatia_ingrediente (id_fatia, ingrediente)
       VALUES (?, ?);
     `;
 
     const values = [
-      result.insertedId,
+      result.insertId,
       element
     ];
 
     connection.query(query, values);
   });
 
-  return result.insertedId;
+  return result.insertId;
 };
 
 //Função para buscar fatia pelo nome
 export async function getFatiaByNome(nome) {
   const query = `
-    SELECT * FROM view_fatia_ingredientes WHERE nome_fatia = ?;
+    SELECT * FROM view_fatia_ingredientes WHERE nome_produto = ?;
   `;
 
   const [fatia] = await connection.query(query, [nome]);
@@ -83,7 +83,7 @@ export async function getFatiaByIngrediente(ingrediente) {
 export async function updateFatia(id, fatia) {
   const query = `
     UPDATE fatia
-    SET nome_fatia = ?, massa = ?, recheio = ?, cobertura = ?, peso_kg = ?, valor = ?
+    SET nome_fatia = ?, massa = ?, recheio = ?, cobertura = ?, peso_g = ?, valor = ?
     WHERE id = ?;
   `;
 

--- a/src/repository/tortaRepository.js
+++ b/src/repository/tortaRepository.js
@@ -3,7 +3,7 @@ import connection from "../services/connection.js";
 // Função para buscar todos os tortas
 export async function getAllTortas() {
   const query = `
-    SELECT * FROM view_torta_ingredientes;
+    SELECT * FROM torta;
   `;
 
   let [tortas] = await connection.query(query);
@@ -31,25 +31,25 @@ export async function addTorta(torta, ingredientes) {
 
   ingredientes.forEach(element => {
     const query = `
-      INSERT INTO torta_ingredientes (id_torta, ingrediente)
+      INSERT INTO torta_ingrediente (id_torta, ingrediente)
       VALUES (?, ?);
     `;
 
     const values = [
-      result.insertedId,
+      result.inserted,
       element
     ];
 
     connection.query(query, values);
   });
 
-  return result.insertedId;
+  return result.insertId;
 };
 
 //Função para buscar torta pelo nome
 export async function getTortaByNome(nome) {
   const query = `
-    SELECT * FROM view_torta_ingredientes WHERE nome_torta = ?;
+    SELECT * FROM view_torta_ingredientes WHERE nome_produto = ?;
   `;
 
   const [torta] = await connection.query(query, [nome]);

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,7 +1,9 @@
 import tortas from "./controller/tortasController.js";
+import fatias from "./controller/fatiasController.js";
 import bolos from "./controller/bolosController.js";
 
 export default function routes(app) {
   app.use(tortas);
+  app.use(fatias);
   app.use(bolos);
 }


### PR DESCRIPTION
This pull request introduces several changes to the database queries and controllers for `fatias`, `bolos`, and `tortas`, alongside adjustments to the routing configuration. The main updates involve modifying table references, improving validation logic, and ensuring consistency in database field names and types.

### Database Query Updates:
* Updated `getAllBolos`, `getAllFatias`, and `getAllTortas` functions to query directly from the base tables (`bolo`, `fatia`, and `torta`) instead of their respective views (`view_bolo_ingredientes`, `view_fatia_ingredientes`, and `view_torta_ingredientes`). [[1]](diffhunk://#diff-e28611211c0a4b7e95de7e47291222e4715273df49a2d0d7ce445746fdaa61c1L6-R6) [[2]](diffhunk://#diff-d0a1661e5fdbc9dc5d9b7550dd060a71c6250d82df9c7aeb248f191f59de59e4L6-R6) [[3]](diffhunk://#diff-f6b6bd3249ea2f941cf48794d95e24c9d18cc5bb6ec189e480f65c4cab917133L6-R6)
* Adjusted `INSERT` queries in `fatiasRepository.js` and `tortaRepository.js` to use singular table names for ingredient associations (`fatia_ingrediente` and `torta_ingrediente`) and corrected the return field for inserted records from `insertedId` to `insertId`. [[1]](diffhunk://#diff-d0a1661e5fdbc9dc5d9b7550dd060a71c6250d82df9c7aeb248f191f59de59e4L34-R52) [[2]](diffhunk://#diff-f6b6bd3249ea2f941cf48794d95e24c9d18cc5bb6ec189e480f65c4cab917133L34-R52)
* Changed `peso_kg` to `peso_g` in `fatiasRepository.js` for consistency with the unit of measurement. [[1]](diffhunk://#diff-d0a1661e5fdbc9dc5d9b7550dd060a71c6250d82df9c7aeb248f191f59de59e4L17-R17) [[2]](diffhunk://#diff-d0a1661e5fdbc9dc5d9b7550dd060a71c6250d82df9c7aeb248f191f59de59e4L86-R86)

### Validation and Logic Improvements:
* Enhanced the validation logic in `fatiasController.js` to check if the `resultExist` array has elements (`resultExist.length > 0`) instead of relying on a truthy check.

### Routing Configuration:
* Added the `fatiasController.js` to the application routes in `src/routes.js` to enable routing for `fatias`.